### PR TITLE
Add scripts for shipping SwiftPM releases

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,21 @@
+# Releasing a SwiftPM package
+
+Once a new version of heap-ios-sdk has shipped to the CDN and CocoaPods, it can be released to SwiftPM the following sequence of
+commands.
+
+```bash
+HEAP_VERSION=8.1.0 # Or whatever the appropriate version is.
+cd scripts
+./prepare-for-release.sh "$HEAP_VERSION"
+git commit -am "Releasing $HEAP_VERSION"
+git push
+# If the current branch isn't master, go through the PR process.
+./release.sh "$HEAP_VERSION"
+```
+
+The first script, `prepare-for-release.sh` is responsible for updating Package.swift, README.md, and CHANGELOG.md with values from
+the zip file on the CDN.  It does not commit the change, leaving that up to the developer.
+
+The second script, `release.sh` must be run on a clean `master` branch without any outstanding changes.  It peforms a handful of
+checks to make sure everything is up-to-date, then pushes a branch with the specified version to the server.  This allows SwiftPM
+to find the updated version of the library.

--- a/scripts/prepare-for-release.sh
+++ b/scripts/prepare-for-release.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+trap "exit" INT TERM ERR
+trap "kill 0" EXIT
+
+set -o errexit
+set -o pipefail
+
+if [[ "undefined$1" = "undefined" ]]
+then
+echo "Usage: $0 HEAP_VERSION"
+exit 1
+fi
+
+HEAP_VERSION=$1
+
+TMP_DIR=$(mktemp -d -t heap-ios-sdk)
+ZIP_FILE="heap-ios-${HEAP_VERSION}.zip"
+ZIP_URL="https://cdn.heapanalytics.com/ios/${ZIP_FILE}"
+ZIP_PATH="${TMP_DIR}/${ZIP_FILE}"
+
+
+
+
+curl -o "$ZIP_PATH" "https://cdn.heapanalytics.com/ios/${ZIP_FILE}"
+
+echo "$TMP_DIR"
+
+CHECKSUM=$(swift package compute-checksum "${ZIP_PATH}")
+
+unzip -o "$ZIP_PATH" CHANGELOG.md README.md -d "../" # Here's where we fail if it's a bad version number.
+
+sed -i '' "s#\"https://cdn.heapanalytics.com/ios/heap-ios-[^\"]*\"#\"${ZIP_URL}\"#; s#\(checksum: \"\)[^\"]*#\1${CHECKSUM}#" ../Package.swift

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+trap "exit" INT TERM ERR
+trap "kill 0" EXIT
+
+set -o errexit
+set -o pipefail
+
+if [[ "undefined$1" = "undefined" ]]
+then
+echo "Usage: $0 HEAP_VERSION"
+exit 1
+fi
+
+REQUIRED_BRANCH="master"
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+if [[ "$CURRENT_BRANCH" != "$REQUIRED_BRANCH" ]]
+then
+echo "You must run this script from the $REQUIRED_BRANCH branch.  You are currently on $CURRENT_BRANCH."
+# exit 1
+fi
+
+if [[ `git status --porcelain` ]]; then
+echo "You cannot run this script with uncommitted changes."
+
+fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -12,16 +12,43 @@ echo "Usage: $0 HEAP_VERSION"
 exit 1
 fi
 
+HEAP_VERSION=$1
 REQUIRED_BRANCH="master"
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 if [[ "$CURRENT_BRANCH" != "$REQUIRED_BRANCH" ]]
 then
 echo "You must run this script from the $REQUIRED_BRANCH branch.  You are currently on $CURRENT_BRANCH."
-# exit 1
+exit 1
 fi
 
-if [[ `git status --porcelain` ]]; then
+if [[ $(git status --porcelain) ]]; then
 echo "You cannot run this script with uncommitted changes."
-
+exit 1
 fi
+
+if [[ `git status -sb` == *ahead* ]]
+then
+echo "You cannot run this script with unpushed changes."
+exit 1
+fi
+
+git pull origin "$CURRENT_BRANCH" --ff-only
+ git fetch --all --tags
+
+if [[ $(git tag -l "$HEAP_VERSION") = "$HEAP_VERSION" ]]
+then
+echo "The $HEAP_VERSION tag already exists."
+exit 1
+fi
+
+if [[ $(grep "heap-ios-$HEAP_VERSION.zip" ../Package.swift)  ]]
+then
+:
+else
+echo "Package.swift does not reference heap-ios-$HEAP_VERSION.zip."
+exit 1
+fi
+
+git tag "$HEAP_VERSION"
+git push origin "$HEAP_VERSION"


### PR DESCRIPTION
We recently added a Package.swift file to this project so Heap could be consumed as a package in Xcode.  This adds scripts that update the various files from the zip file on the server and tag the release on GitHub.

More details can be found in the added scripts/README.md